### PR TITLE
Add feature-branch continual deployment for directory-api

### DIFF
--- a/directory-api.yaml
+++ b/directory-api.yaml
@@ -3,9 +3,9 @@ name: directory-api
 namespace: directory
 scm: git@github.com:uktrade/directory-api.git
 environments:
-  - environment: dev
+  - environment: cd-feature
     type: gds
-    app: dit-staging/dev-directory/directory-api-dev
+    app: dit-staging/staging-directory/directory-api-cd-feature
     vars: []
     secrets: true
     run: []


### PR DESCRIPTION
The 'dev' environment that this replaces I suspect wasn't doing anything, since

  - dev deployments for directory api are currently in Heroku

  - The space 'dev-directory' is actually used by
    directory-companies-house-search, and this file only concerns
    directory-api.git