### PR TITLE
(feat) Config for activity stream proxy

### DIFF
--- a/activity-stream-proxy.yaml
+++ b/activity-stream-proxy.yaml
@@ -1,0 +1,11 @@
+---
+name: activity-stream-proxy
+namespace: activity-stream-proxy
+scm: git@github.com:uktrade/activity-stream-proxy.git
+environments:
+  - environment: dev
+    type: gds
+    app: dit-staging/dev-activity-stream/activity-stream-proxy-dev
+    vars: []
+    secrets: true
+    run: []


### PR DESCRIPTION
We only have the dev environment for pen testing. We don't actually plan to use
this in production: it's a "just in case" project, jfor pen testing now, so we
can quickly use a stand alone endpoint down the line without having to wait+pay
for another round of pen-testing.