### PR TITLE
Add `APPLICATION_ENV` for People Finder and Workspace

### DIFF
--- a/digital-workspace.yaml
+++ b/digital-workspace.yaml
@@ -7,6 +7,7 @@ environments:
     app: dit-staging/dev-intranet/digital-workspace-dev
     vars:
       - API: 'digital-workspace-dev.cloudapps.digital/'
+      - APPLICATION_ENV: dev
     secrets: true
     run:
       - "true"
@@ -14,6 +15,7 @@ environments:
     type: gds
     app: dit-staging/staging-intranet/digital-workspace-staging
     vars:
+      - APPLICATION_ENV: staging
       - DISABLE_COLLECTSTATIC: 1
     secrets: true
     run:
@@ -22,6 +24,7 @@ environments:
     type: gds
     app: dit-services/intranet/digital-workspace
     vars:
+      - APPLICATION_ENV: production
       - DISABLE_COLLECTSTATIC: 1
     secrets: true
     run:

--- a/peoplefinder.yaml
+++ b/peoplefinder.yaml
@@ -7,6 +7,7 @@ environments:
     type: gds
     app: dit-staging/dev-intranet/peoplefinder-dev
     vars:
+      - APPLICATION_ENV: dev
       - DISABLE_COLLECTSTATIC: 1
     secrets: true
     run:
@@ -15,6 +16,7 @@ environments:
     type: gds
     app: dit-staging/staging-intranet/peoplefinder-staging
     vars:
+      - APPLICATION_ENV: staging
       - DISABLE_COLLECTSTATIC: 1
     secrets: true
     run:
@@ -23,6 +25,7 @@ environments:
     type: gds
     app: dit-services/intranet/peoplefinder
     vars:
+      - APPLICATION_ENV: production
       - DISABLE_COLLECTSTATIC: 1
     secrets: true
     run:


### PR DESCRIPTION
Errors from People Finder and Digital Workspace show up as coming from
the `production` environment in Sentry, regardless of whether they come
from dev, staging, or prod. This is because Raven picks up on the Rails
environment by default, which (correctly) is `production` for all three.

This adds an environment variable `APPLICATION_ENV` which we can use in
the applications to configure Raven to report the environment the apps
are actually running in.