### PR TITLE
Revert "Add `APPLICATION_ENV` for People Finder and Workspace"

### DIFF
--- a/digital-workspace.yaml
+++ b/digital-workspace.yaml
@@ -7,7 +7,6 @@ environments:
     app: dit-staging/dev-intranet/digital-workspace-dev
     vars:
       - API: 'digital-workspace-dev.cloudapps.digital/'
-      - APPLICATION_ENV: dev
     secrets: true
     run:
       - "true"
@@ -15,7 +14,6 @@ environments:
     type: gds
     app: dit-staging/staging-intranet/digital-workspace-staging
     vars:
-      - APPLICATION_ENV: staging
       - DISABLE_COLLECTSTATIC: 1
     secrets: true
     run:
@@ -24,7 +22,6 @@ environments:
     type: gds
     app: dit-services/intranet/digital-workspace
     vars:
-      - APPLICATION_ENV: production
       - DISABLE_COLLECTSTATIC: 1
     secrets: true
     run:

--- a/peoplefinder.yaml
+++ b/peoplefinder.yaml
@@ -7,7 +7,6 @@ environments:
     type: gds
     app: dit-staging/dev-intranet/peoplefinder-dev
     vars:
-      - APPLICATION_ENV: dev
       - DISABLE_COLLECTSTATIC: 1
     secrets: true
     run:
@@ -16,7 +15,6 @@ environments:
     type: gds
     app: dit-staging/staging-intranet/peoplefinder-staging
     vars:
-      - APPLICATION_ENV: staging
       - DISABLE_COLLECTSTATIC: 1
     secrets: true
     run:
@@ -25,7 +23,6 @@ environments:
     type: gds
     app: dit-services/intranet/peoplefinder
     vars:
-      - APPLICATION_ENV: production
       - DISABLE_COLLECTSTATIC: 1
     secrets: true
     run:


### PR DESCRIPTION
Reverts uktrade/ci-pipeline-config#41

@cstutter is moving these env vars into vault, so we're reverting this commit.