### PR TITLE
Kibana in own repo

### DIFF
--- a/activity-stream-kibana.yaml
+++ b/activity-stream-kibana.yaml
@@ -1,21 +1,17 @@
 ---
 name: activity-stream-kibana
 namespace: activity-stream
-scm: git@github.com:uktrade/activity-stream.git
+scm: git@github.com:uktrade/kibana-paas.git
 environments:
   - environment: dev-eu-west-2
     type: gds
     region: eu-west-2
     app: dit-staging/activity-stream-dev/activity-stream-kibana-dev
-    vars:
-      - APP_PATH: kibana
     secrets: true
     run: []
   - environment: production-eu-west-2
     type: gds
     region: eu-west-2
     app: dit-services/activity-stream/activity-stream-kibana
-    vars:
-      - APP_PATH: kibana
     secrets: true
     run: []


### PR DESCRIPTION
APP_PATH can't be used to specify manifest.yml location, so can't have a repo
that needs different ones, i.e. one for docker and one for buildpack.