### PR TITLE
Add trade-tariff-reference training config

### DIFF
--- a/trade-tariff-reference.yaml
+++ b/trade-tariff-reference.yaml
@@ -17,6 +17,13 @@ environments:
     vars: []
     secrets: true
     run: []
+  - environment: training
+    region: eu-west-2
+    type: gds
+    app: dit-staging/tariffs-training/tariff-reference-training
+    vars: []
+    secrets: true
+    run: []
   - environment: production
     region: eu-west-2
     type: gds


### PR DESCRIPTION
This adds the ci-pipeline configuration for training for the trade-tariff-reference application.
https://github.com/uktrade/trade-tariff-reference