### PR TITLE
creating beta environment for great-cms

### DIFF
--- a/great-cms.yaml
+++ b/great-cms.yaml
@@ -31,3 +31,10 @@ environments:
     vars: []
     secrets: true
     run: []
+  - environment: beta
+    type: gds
+    region: eu-west-2
+    app: dit-services/directory/great-cms-beta
+    vars: []
+    secrets: true
+    run: []


### PR DESCRIPTION
a new environment for great-cms to be used in the UR first and then as beta.great once the new site launches in Q4.