### PR TITLE
Consolidate LITE frontend repos

### DIFF
--- a/lite-exporter-frontend.yaml
+++ b/lite-exporter-frontend.yaml
@@ -1,7 +1,7 @@
 ---
 name: lite-exporter-frontend
 namespace: lite
-scm: git@github.com:uktrade/lite-exporter-frontend.git
+scm: git@github.com:uktrade/lite-frontend.git
 environments:
   - environment: dev
     type: gds

--- a/lite-internal-frontend.yaml
+++ b/lite-internal-frontend.yaml
@@ -1,7 +1,7 @@
 ---
 name: lite-internal-frontend
 namespace: lite
-scm: git@github.com:uktrade/lite-internal-frontend.git
+scm: git@github.com:uktrade/lite-frontend.git
 environments:
   - environment: dev
     type: gds


### PR DESCRIPTION
LITE exporter and internal apps will now be contained in the same repository
with environment variables controlling which interface is shown. The ci-pipline
should pull the code from the same repo for both.