### PR TITLE
Add a UAT environment to Enquiry Mgmt Tool

### DIFF
--- a/enquiry-mgmt-tool.yaml
+++ b/enquiry-mgmt-tool.yaml
@@ -10,6 +10,13 @@ environments:
     vars: []
     secrets: true
     run: []
+  - environment: uat
+    type: gds
+    region: eu-west-2
+    app: dit-staging/enquiry-mgmt-tool-uat/enquiry-mgmt-tool-uat
+    vars: []
+    secrets: true
+    run: []
   - environment: staging
     type: gds
     region: eu-west-2


### PR DESCRIPTION
This is specifically to support the Adobe Campaign integration work in the first instance.