### PR TITLE
Update icms-hmrc.yaml

### DIFF
--- a/icms-hmrc.yaml
+++ b/icms-hmrc.yaml
@@ -1,6 +1,6 @@
 ---
 name: icms-hmrc
-namespace: live-services
+namespace: icms
 scm: git@github.com:uktrade/icms-hmrc
 environments:
   - environment: dev


### PR DESCRIPTION
Changed namespace to match the Vault dit/icms secrets (which were originally created in live-services/icms-hmrc). And then cross fingers this will get the Jenkins pipeline past the 404 error when running `/home/jenkins/agent/workspace/ci-pipeline/.ci/bootstrap.rb unlock icms/icms-hmrc/dev`.