### PR TITLE
Add configuration for TaMaTo prototype application

### DIFF
--- a/manage-trade-tariffs-design.yaml
+++ b/manage-trade-tariffs-design.yaml
@@ -6,7 +6,7 @@ environments:
   - environment: development
     type: gds
     region: eu-west-2
-    app: dit-staging/tariffs-dev/manage-trade-tariffs-design
+    app: dit-staging/tariffs-dev/manage-trade-tariffs-design-dev
     vars: []
     secrets: true
     run: []
@@ -21,6 +21,12 @@ environments:
     type: gds
     region: eu-west-2
     app: dit-staging/tariffs-staging/manage-trade-tariffs-design-staging
+    vars: []
+    secrets: true
+    run: []
+  - environment: production
+    type: gds
+    app: dit-services/tariffs/tamato/manage-trade-tariffs-design
     vars: []
     secrets: true
     run: []

--- a/manage-trade-tariffs-design.yaml
+++ b/manage-trade-tariffs-design.yaml
@@ -1,0 +1,26 @@
+---
+name: manage-trade-tariffs-design
+namespace: trade-tariffs
+scm: git@github.com:uktrade/manage-trade-tariffs-design.git
+environments:
+  - environment: development
+    type: gds
+    region: eu-west-2
+    app: dit-staging/tariffs-dev/manage-trade-tariffs-design
+    vars: []
+    secrets: true
+    run: []
+  - environment: uat
+    type: gds
+    region: eu-west-2
+    app: dit-staging/tariffs-uat/manage-trade-tariffs-design-uat
+    vars: []
+    secrets: true
+    run: []
+  - environment: staging
+    type: gds
+    region: eu-west-2
+    app: dit-staging/tariffs-staging/manage-trade-tariffs-design-staging
+    vars: []
+    secrets: true
+    run: []


### PR DESCRIPTION
Adds a `.yaml` for the prototype application used by the tariff management tool (known as manage-trade-tariffs-design); this app is used internally to demonstrate design ideas.