### PR TITLE
Update tamato test env app details 

### DIFF
--- a/tamato.yaml
+++ b/tamato.yaml
@@ -20,7 +20,7 @@ environments:
   - environment: test 
     type: gds
     region: eu-west-2
-    app: dit-staging/tariffs-staging/tamato-test
+    app: dit-staging/tariffs-test/tamato-test
     vars: []
     secrets: true
     run: []


### PR DESCRIPTION
We no longer have a staging space, so deployments to our test environment are currently failing.