### PR TITLE
Add pipeline for the data-hub-api Prom RQ exporter

### DIFF
--- a/data-hub-api-redis-queue-exporter.yaml
+++ b/data-hub-api-redis-queue-exporter.yaml
@@ -5,7 +5,7 @@ environments:
   - environment: dev
     region: eu-west-2
     type: gds
-    app: dit-staging/webops-dev/data-hub-api-redis-queue-exporter
+    app: dit-staging/webops-dev/data-hub-api-redis-queue-exporter-dev
     vars: []
     secrets: true
     run: []

--- a/data-hub-api-redis-queue-exporter.yaml
+++ b/data-hub-api-redis-queue-exporter.yaml
@@ -1,0 +1,11 @@
+name: data-hub-api-redis-queue-exporter
+namespace: webops
+scm: git@github.com:uktrade/data-hub-api.git
+environments:
+  - environment: dev
+    region: eu-west-2
+    type: gds
+    app: dit-staging/webops-dev/data-hub-api-redis-queue-exporter
+    vars: []
+    secrets: true
+    run: []


### PR DESCRIPTION
Makes the following changes:
- Add a pipeline file for `data-hub-api-redis-queue-exporter` (dev environment)
- Currently set to `webops` space for testing.

Further updates to follow to switch space to datahub, and add further environments.