### PR TITLE
Change scm repo to prom-rq-exporter

### DIFF
--- a/data-hub-api-redis-queue-exporter.yaml
+++ b/data-hub-api-redis-queue-exporter.yaml
@@ -1,6 +1,6 @@
 name: data-hub-api-redis-queue-exporter
 namespace: webops
-scm: git@github.com:uktrade/data-hub-api.git
+scm: git@github.com:uktrade/prom-rq-exporter.git
 environments:
   - environment: dev
     region: eu-west-2


### PR DESCRIPTION
Updates the SCM repo from `data-hub-api.git` (shared) to `prom-rq-exporter.git` (dedicated).