### PR TITLE
Rename instances of "data-hub" to "datahub"

### DIFF
--- a/datahub-api-redis-queue-exporter.yaml
+++ b/datahub-api-redis-queue-exporter.yaml
@@ -1,11 +1,11 @@
-name: data-hub-api-redis-queue-exporter
+name: datahub-api-redis-queue-exporter
 namespace: webops
 scm: git@github.com:uktrade/prom-rq-exporter.git
 environments:
   - environment: dev
     region: eu-west-2
     type: gds
-    app: dit-staging/datahub-dev/data-hub-api-redis-queue-exporter-dev
+    app: dit-staging/datahub-dev/datahub-api-redis-queue-exporter-dev
     vars: []
     secrets: true
     run: []


### PR DESCRIPTION
Applies the following change:
- Rename the application names from "data-hub" to "datahub" to match existing apps.
- As above with the pipeline config file.