### PR TITLE
Renaming johnny to chicago, chris to tokyo

### DIFF
--- a/trade-remedies-api.yaml
+++ b/trade-remedies-api.yaml
@@ -3,10 +3,10 @@ name: trade-remedies-api
 namespace: traderemedies
 scm: git@github.com:uktrade/trade-remedies-api.git
 environments:
-  - environment: christopher-eu-west-2
+  - environment: tokyo-eu-west-2
     type: gds
     region: eu-west-2
-    app: traderemedies-staging/traderemedies-dev/trade-remedies-api-chris
+    app: traderemedies-staging/traderemedies-dev/trade-remedies-api-tokyo
     vars: []
     secrets: true
     run:

--- a/trade-remedies-api.yaml
+++ b/trade-remedies-api.yaml
@@ -11,10 +11,10 @@ environments:
     secrets: true
     run:
       - "true"
-  - environment: johnny-eu-west-2
+  - environment: chicago-eu-west-2
     type: gds
     region: eu-west-2
-    app: traderemedies-staging/traderemedies-dev/trade-remedies-api-johnny
+    app: traderemedies-staging/traderemedies-dev/trade-remedies-api-chicago
     vars: []
     secrets: true
     run:

--- a/trade-remedies-caseworker.yaml
+++ b/trade-remedies-caseworker.yaml
@@ -11,10 +11,10 @@ environments:
     secrets: true
     run:
       - "true"
-  - environment: johnny-eu-west-2
+  - environment: chicago-eu-west-2
     type: gds
     region: eu-west-2
-    app: traderemedies-staging/traderemedies-dev/trade-remedies-caseworker-johnny
+    app: traderemedies-staging/traderemedies-dev/trade-remedies-caseworker-chicago
     vars: []
     secrets: true
     run:

--- a/trade-remedies-caseworker.yaml
+++ b/trade-remedies-caseworker.yaml
@@ -3,10 +3,10 @@ name: trade-remedies-caseworker
 namespace: traderemedies
 scm: git@github.com:uktrade/trade-remedies-caseworker.git
 environments:
-  - environment: christopher-eu-west-2
+  - environment: tokyo-eu-west-2
     type: gds
     region: eu-west-2
-    app: traderemedies-staging/traderemedies-dev/trade-remedies-caseworker-chris
+    app: traderemedies-staging/traderemedies-dev/trade-remedies-caseworker-tokyo
     vars: []
     secrets: true
     run:

--- a/trade-remedies-public.yaml
+++ b/trade-remedies-public.yaml
@@ -11,10 +11,10 @@ environments:
     secrets: true
     run:
       - "true"
-  - environment: johnny-eu-west-2
+  - environment: chicago-eu-west-2
     type: gds
     region: eu-west-2
-    app: traderemedies-staging/traderemedies-dev/trade-remedies-public-johnny
+    app: traderemedies-staging/traderemedies-dev/trade-remedies-public-chicago
     vars: []
     secrets: true
     run:

--- a/trade-remedies-public.yaml
+++ b/trade-remedies-public.yaml
@@ -3,10 +3,10 @@ name: trade-remedies-public
 namespace: traderemedies
 scm: git@github.com:uktrade/trade-remedies-public.git
 environments:
-  - environment: christopher-eu-west-2
+  - environment: tokyo-eu-west-2
     type: gds
     region: eu-west-2
-    app: traderemedies-staging/traderemedies-dev/trade-remedies-public-chris
+    app: traderemedies-staging/traderemedies-dev/trade-remedies-public-tokyo
     vars: []
     secrets: true
     run:


### PR DESCRIPTION
Replacing developer names with generic cities to make it easier to assign and share environments between developers which come and go.