### PR TITLE
Remove dev-a environment from data-flow

### DIFF
--- a/datasci-data-flow.yaml
+++ b/datasci-data-flow.yaml
@@ -10,13 +10,6 @@ environments:
     vars: []
     secrets: true
     run: []
-  - environment: dev-a
-    type: gds
-    region: eu-west-2
-    app: dit-staging/datasci-dev/data-flow-dev-a
-    vars: []
-    secrets: true
-    run: []
   - environment: staging
     type: gds
     region: eu-west-2


### PR DESCRIPTION
The dev-a environment of data-flow no longer exists, and hasn't for a while, so there isn't a need for its config file.

This is being done because we're about to add some more apps to the data-flow setup, so cleaning house a bit first so that setup is as clear as it can be.