### PR TITLE
Add data-flow-data-infrastructure config

### DIFF
--- a/datasci-data-flow-data-infrastructure.yaml
+++ b/datasci-data-flow-data-infrastructure.yaml
@@ -1,0 +1,26 @@
+---
+name: data-flow-data-infrastructure
+namespace: datasci
+scm: git@github.com:uktrade/data-flow.git
+environments:
+  - environment: dev
+    type: gds
+    region: eu-west-2
+    app: dit-staging/datasci-dev/data-flow-data-infrastructure-dev
+    vars: []
+    secrets: true
+    run: []
+  - environment: staging
+    type: gds
+    region: eu-west-2
+    app: dit-staging/datasci-staging/data-flow-data-infrastructure-staging
+    vars: []
+    secrets: true
+    run: []
+  - environment: production
+    type: gds
+    region: eu-west-2
+    app: dit-services/datasci/data-flow-data-infrastructure
+    vars: []
+    secrets: true
+    run: []


### PR DESCRIPTION
data-flow is being split into multiple GOV.UK PaaS apps

- One "core" one for the Airflow webserver and Airflow scheduler
- Then one per team of people that write and maintain DAGs that will run Airflow's DAG processor, and run the Airflow tasks themselves.

This is primarily to separate the credentials for the various components, so everything doesn't get access to everything. The webserver and scheduler don't need credentials to access data, and also each team's DAGs don't need access to the credentials for other teams' DAGs.

Since Data Infrastructure is de-facto responsible for all the DAGs, this is the first team chosen to split out, hence the name of this application.