### PR TITLE
feat: add data-flow-data-science config

### DIFF
--- a/datasci-data-flow-data-science.yaml
+++ b/datasci-data-flow-data-science.yaml
@@ -1,0 +1,26 @@
+---
+name: data-flow-data-science
+namespace: datasci
+scm: git@github.com:uktrade/data-flow.git
+environments:
+  - environment: dev
+    type: gds
+    region: eu-west-2
+    app: dit-staging/datasci-dev/data-flow-data-science-dev
+    vars: []
+    secrets: true
+    run: []
+  - environment: staging
+    type: gds
+    region: eu-west-2
+    app: dit-staging/datasci-staging/data-flow-data-science-staging
+    vars: []
+    secrets: true
+    run: []
+  - environment: production
+    type: gds
+    region: eu-west-2
+    app: dit-services/datasci/data-flow-data-science
+    vars: []
+    secrets: true
+    run: []


### PR DESCRIPTION
This adds a config for a data-flow-data-science app, just like the similar apps data-flow-data-infrastructure and data-flow-gscip.

These are used in data-flow run the dags that a particular team are responsible for, and separated from each other to better isolate credentials.