### PR TITLE
feat: add data-flow app for DAGs from the OPSS

### DIFF
--- a/datasci-data-flow-opss.yaml
+++ b/datasci-data-flow-opss.yaml
@@ -1,0 +1,26 @@
+---
+name: data-flow-opss
+namespace: datasci
+scm: git@github.com:uktrade/data-flow.git
+environments:
+  - environment: dev
+    type: gds
+    region: eu-west-2
+    app: dit-staging/datasci-dev/data-flow-opss-dev
+    vars: []
+    secrets: true
+    run: []
+  - environment: staging
+    type: gds
+    region: eu-west-2
+    app: dit-staging/datasci-staging/data-flow-opss-staging
+    vars: []
+    secrets: true
+    run: []
+  - environment: production
+    type: gds
+    region: eu-west-2
+    app: dit-services/datasci/data-flow-opss
+    vars: []
+    secrets: true
+    run: []


### PR DESCRIPTION
The OPSS are going to be making DAGs to run in data-flow. We now have per-team folders in data-flow that correspond to separate apps in paas for better separation, so it makes sense to make one for the OPSS.