### PR TITLE
feat: add config for data-flow-tap application

### DIFF
--- a/datasci-data-flow-tap.yaml
+++ b/datasci-data-flow-tap.yaml
@@ -1,0 +1,26 @@
+---
+name: data-flow-tap
+namespace: datasci
+scm: git@github.com:uktrade/data-flow.git
+environments:
+  - environment: dev
+    type: gds
+    region: eu-west-2
+    app: dit-staging/datasci-dev/data-flow-tap-dev
+    vars: []
+    secrets: true
+    run: []
+  - environment: staging
+    type: gds
+    region: eu-west-2
+    app: dit-staging/datasci-staging/data-flow-tap-staging
+    vars: []
+    secrets: true
+    run: []
+  - environment: production
+    type: gds
+    region: eu-west-2
+    app: dit-services/datasci/data-flow-tap
+    vars: []
+    secrets: true
+    run: []


### PR DESCRIPTION
We're separating out some TAP/TaMaTo-specific pipelines in data-flow, so they can be managed separately to other pipelines. This is done via a separate Cloud Foundry application, deployed using this config.